### PR TITLE
Update site navigation and add case carousel

### DIFF
--- a/src/components/CaseCarousel.css
+++ b/src/components/CaseCarousel.css
@@ -1,0 +1,53 @@
+.case-carousel {
+  position: relative;
+  overflow: hidden;
+}
+
+.carousel-track {
+  display: flex;
+  transition: transform 0.4s ease;
+}
+
+.case-card {
+  flex: 0 0 320px;
+  margin-right: 1rem;
+}
+
+.carousel-btn {
+  position: absolute;
+  top: 40%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid #e0e0e0;
+  background: white;
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+}
+.carousel-btn.prev { left: 0; }
+.carousel-btn.next { right: 0; }
+.carousel-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 1rem;
+}
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #ccc;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+.dot.active {
+  background: var(--accent-color);
+}

--- a/src/components/CaseCarousel.jsx
+++ b/src/components/CaseCarousel.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import './CaseCarousel.css';
+
+const CaseCarousel = ({ cases }) => {
+  const [index, setIndex] = useState(0);
+  const lastIndex = cases.length - 1;
+
+  const prev = () => setIndex(i => Math.max(i - 1, 0));
+  const next = () => setIndex(i => Math.min(i + 1, lastIndex));
+
+  return (
+    <div className="case-carousel">
+      <button className="carousel-btn prev" onClick={prev} disabled={index === 0} aria-label="Previous">
+        ‹
+      </button>
+      <div className="carousel-track" style={{ transform: `translateX(-${index * 100}%)` }}>
+        {cases.map(caseStudy => (
+          <Link
+            to={`/portfolio/${caseStudy.id}`}
+            key={caseStudy.id}
+            className="case-card"
+          >
+            <div className="case-image">
+              {caseStudy.image ? (
+                <img src={caseStudy.image} alt={caseStudy.headline} />
+              ) : (
+                <div className="image-placeholder">
+                  <span>{caseStudy.client}</span>
+                </div>
+              )}
+            </div>
+            <div className="case-content">
+              <h4 className="case-headline">{caseStudy.headline}</h4>
+              <p className="case-challenge">{caseStudy.challenge}</p>
+              <div className="case-meta">
+                <div className="tech-tags">
+                  {caseStudy.techStack.map((tech, idx) => (
+                    <span key={idx} className="tech-tag">{tech}</span>
+                  ))}
+                </div>
+                <div className="timeframe">
+                  <span className="timeframe-label">Delivered in</span>
+                  <span className="timeframe-value">{caseStudy.timeframe}</span>
+                </div>
+              </div>
+              <div className="case-metrics">
+                {caseStudy.metrics.map((metric, idx) => (
+                  <div key={idx} className="metric-box">{metric}</div>
+                ))}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+      <button className="carousel-btn next" onClick={next} disabled={index === lastIndex} aria-label="Next">
+        ›
+      </button>
+      <div className="carousel-dots">
+        {cases.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => setIndex(i)}
+            className={`dot${i === index ? ' active' : ''}`}
+            aria-label={`Slide ${i + 1}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CaseCarousel;

--- a/src/components/CaseStudies.jsx
+++ b/src/components/CaseStudies.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { portfolioCategories } from '../data/portfolio';
+import CaseCarousel from './CaseCarousel';
 import './CaseStudies.css';
 
 const CaseStudies = () => {
@@ -17,54 +18,7 @@ const CaseStudies = () => {
             <h3 className="category-title">{category.title}</h3>
             <p className="category-description">{category.description}</p>
             
-            <div className="cases-grid">
-              {category.cases.map(caseStudy => (
-                <Link 
-                  to={`/portfolio/${caseStudy.id}`} 
-                  key={caseStudy.id} 
-                  className="case-card"
-                >
-                  {/* Placeholder for image - will show when images are added */}
-                  <div className="case-image">
-                    {caseStudy.image && (
-                      <img src={caseStudy.image} alt={caseStudy.headline} />
-                    )}
-                    {!caseStudy.image && (
-                      <div className="image-placeholder">
-                        <span>{caseStudy.client}</span>
-                      </div>
-                    )}
-                  </div>
-                  
-                  <div className="case-content">
-                    <h4 className="case-headline">{caseStudy.headline}</h4>
-                    
-                    <p className="case-challenge">{caseStudy.challenge}</p>
-                    
-                    <div className="case-meta">
-                      <div className="tech-tags">
-                        {caseStudy.techStack.map((tech, index) => (
-                          <span key={index} className="tech-tag">{tech}</span>
-                        ))}
-                      </div>
-                      
-                      <div className="timeframe">
-                        <span className="timeframe-label">Delivered in</span>
-                        <span className="timeframe-value">{caseStudy.timeframe}</span>
-                      </div>
-                    </div>
-                    
-                    <div className="case-metrics">
-                      {caseStudy.metrics.map((metric, index) => (
-                        <div key={index} className="metric-box">
-                          {metric}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </Link>
-              ))}
-            </div>
+            <CaseCarousel cases={category.cases} />
           </div>
         ))}
         

--- a/src/components/PortfolioSlideNav.css
+++ b/src/components/PortfolioSlideNav.css
@@ -68,12 +68,6 @@
   color: #333;
 }
 
-.nav-subtitle {
-  font-size: 0.875rem;
-  color: #666;
-  margin: 4px 0 0 0;
-}
-
 /* Navigation Categories */
 .nav-categories {
   flex: 1;

--- a/src/components/PortfolioSlideNav.jsx
+++ b/src/components/PortfolioSlideNav.jsx
@@ -16,20 +16,17 @@ const PortfolioSlideNav = ({ categories, currentCaseId, onCaseSelect, isOpen, on
 
   return (
     <>
-      <button 
+      <button
         className="menu-toggle"
         onClick={onToggle}
         aria-label="Toggle navigation menu"
       >
-        <span className="menu-icon">
-          {isOpen ? '×' : '☰'}
-        </span>
+        <span className="menu-icon">☰</span>
       </button>
 
       <nav className={`portfolio-nav ${isOpen ? 'open' : 'closed'}`}>
         <div className="nav-header">
           <h2>Case Studies</h2>
-          <p className="nav-subtitle">Click to navigate</p>
         </div>
 
         <div className="nav-categories">

--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -102,7 +102,7 @@ export const WaysOfWorking = () => {
         
         <div className="working-philosophy">
           <h3>Our Core Principle: You Own the Future</h3>
-          <p>Every solution we build is designed for your team to own, operate, and evolve. We believe in empowering your organization with:</p>
+          <p>Every solution we build is designed for your organisation to own, operate and evolve. We believe in empowering your organisation with:</p>
           <div className="philosophy-points">
             {philosophyPoints.map((point, index) => (
               <div key={index} className="philosophy-item">
@@ -113,10 +113,10 @@ export const WaysOfWorking = () => {
           </div>
           <div className="philosophy-footer">
             <p className="philosophy-highlight">
-              Whether you need a quick POC, full implementation, or strategic guidance, we adapt to your needs.
+              Whether you require a quick proof of concept, fractional expertise or full project delivery, we adapt to your organisation's needs.
             </p>
             <p className="philosophy-subtext">
-              From individual expert consultants to full delivery teams, from 2-week sprints to multi-year transformations - we scale to match your requirements.
+              We can embed alongside your team on a part-time basis or provide end-to-end delivery, scaling from two-week sprints to multi-year transformations.
             </p>
           </div>
         </div>

--- a/src/data/team.js
+++ b/src/data/team.js
@@ -139,17 +139,6 @@ export const engagementModels = [
       "Strategic partner introductions",
       "Transition planning"
     ]
-  },
-  {
-    icon: "🤝",
-    title: "Flexible Resourcing",
-    description: "Access our network of pre-vetted specialists for specific needs - from data engineers to industry experts. Scale up or down as your project evolves.",
-    features: [
-      "On-demand expertise",
-      "Pre-vetted specialists",
-      "Flexible team scaling",
-      "Single point of contact"
-    ]
   }
 ];
 

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -19,7 +19,8 @@ const Portfolio = () => {
   const [activeIndex, setActiveIndex] = useState(
     currentCaseIndex >= 0 ? currentCaseIndex : 0
   );
-  const [isMenuOpen, setIsMenuOpen] = useState(true);
+  // Start with the navigation menu collapsed
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   
   const currentCase = allCases[activeIndex];


### PR DESCRIPTION
## Summary
- collapse portfolio navigation on load and simplify menu icon
- remove navigation subtitle
- add carousel component for home page case studies
- update about page philosophy text and remove flexible resourcing model

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd57100f083238cbd5ddc59bb3375