### PR TITLE
Fix portfolio slide scroll position

### DIFF
--- a/src/components/CaseStudySlide.jsx
+++ b/src/components/CaseStudySlide.jsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import './CaseStudySlide.css';
 
 const CaseStudySlide = ({ caseStudy }) => {
   const { details } = caseStudy;
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+  }, [caseStudy]);
   
   // Different slide layouts based on content
   const renderSlideContent = () => {
@@ -145,7 +152,7 @@ const CaseStudySlide = ({ caseStudy }) => {
   );
 
   return (
-    <div className="case-study-slide">
+    <div className="case-study-slide" ref={containerRef}>
       {renderSlideContent()}
     </div>
   );


### PR DESCRIPTION
## Summary
- reset scroll position when switching portfolio slides so content starts at the top

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850693dcd5c832393e8436ae89b0a11