### PR TITLE
Add SEO metadata with react-helmet-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-helmet-async": "^1.3.0",
         "react-router-dom": "^6.21.1"
       },
       "devDependencies": {
@@ -253,6 +254,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -981,6 +991,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1068,6 +1087,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1104,6 +1132,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1128,6 +1167,35 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -1206,6 +1274,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.21.1"
   },
   "devDependencies": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
 import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </React.StrictMode>
 )

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 import Hero from '../components/Hero'
 import { TeamSection, ApproachSection, WaysOfWorking } from '../components/Team'
+import shareImage from '/src/assets/images/about/team/david-edgeley.jpg'
 
 export default function About() {
   const location = useLocation();
+  const canonical = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${location.pathname}`
 
   useEffect(() => {
     // Scroll to ways-of-working section if coming from home page
@@ -22,7 +25,27 @@ export default function About() {
 
   return (
     <div className="about">
-      <Hero 
+      <Helmet>
+        <title>About - Data &amp; AI Analytics Consultancy</title>
+        <meta
+          name="description"
+          content="Learn about our data-driven team and how we integrate seamlessly with private equity firms."
+        />
+        <meta
+          name="keywords"
+          content="private equity, analytics team, data science, consultancy"
+        />
+        <link rel="canonical" href={canonical} />
+        <meta property="og:title" content="About - Data &amp; AI Analytics Consultancy" />
+        <meta
+          property="og:description"
+          content="Meet the experts transforming deal intelligence with data and AI."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:image" content={shareImage} />
+      </Helmet>
+      <Hero
         title="Data-Driven Leaders with PE DNA"
         subtitle="Combining technical excellence with deep transaction experience"
         subtext="We integrate seamlessly with your teams to deliver solutions you own and control"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,9 +1,14 @@
 import React from 'react'
+import { useLocation } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
 import Hero from '../components/Hero'
 import Services from '../components/Services'
 import CaseStudies from '../components/CaseStudies'
+import shareImage from '/src/assets/images/about/team/david-edgeley.jpg'
 
 export default function Home() {
+  const location = useLocation()
+  const canonical = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${location.pathname}`
   const scrollToCaseStudies = (e) => {
     e.preventDefault();
     const target = document.getElementById('case-studies');
@@ -30,7 +35,27 @@ export default function Home() {
 
   return (
     <div className="home">
-      <Hero 
+      <Helmet>
+        <title>Data &amp; AI Analytics Consultancy</title>
+        <meta
+          name="description"
+          content="Private equity analytics consultancy delivering data-driven insights across the investment lifecycle."
+        />
+        <meta
+          name="keywords"
+          content="private equity analytics, data analytics, due diligence, portfolio optimization"
+        />
+        <link rel="canonical" href={canonical} />
+        <meta property="og:title" content="Data &amp; AI Analytics Consultancy" />
+        <meta
+          property="og:description"
+          content="Transform deal intelligence with data and AI."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:image" content={shareImage} />
+      </Helmet>
+      <Hero
         title="Transform Deal Intelligence with Data & AI"
         subtitle="From due diligence to portfolio optimization, we deliver actionable insights that drive value creation"
         subtext="Your single source of truth across the entire investment lifecycle"

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,14 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import { portfolioCategories, getAllCases, getCaseById } from '../data/portfolio';
 import PortfolioSlideNav from '../components/PortfolioSlideNav';
 import CaseStudySlide from '../components/CaseStudySlide';
 import SlideControls from '../components/SlideControls';
 import './Portfolio.css';
+import shareImage from '/src/assets/images/about/team/david-edgeley.jpg';
 
 const Portfolio = () => {
   const { caseId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const canonical = `${window.location.origin}${import.meta.env.BASE_URL.replace(/\/$/, '')}${location.pathname}`;
   const allCases = getAllCases();
   
   // Find current case or default to first
@@ -134,6 +138,26 @@ const Portfolio = () => {
 
   return (
     <div className={`portfolio-container ${isFullscreen ? 'fullscreen' : ''}`}>
+      <Helmet>
+        <title>Portfolio - Data &amp; AI Analytics Consultancy</title>
+        <meta
+          name="description"
+          content="Explore case studies showcasing our private equity analytics expertise."
+        />
+        <meta
+          name="keywords"
+          content="portfolio, case studies, private equity analytics, data projects"
+        />
+        <link rel="canonical" href={canonical} />
+        <meta property="og:title" content="Portfolio - Data &amp; AI Analytics Consultancy" />
+        <meta
+          property="og:description"
+          content="Discover how we leverage data and AI to create value across the investment lifecycle."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:image" content={shareImage} />
+      </Helmet>
       <PortfolioSlideNav
         categories={portfolioCategories}
         currentCaseId={currentCase.id}


### PR DESCRIPTION
## Summary
- install `react-helmet-async`
- wrap the app with `<HelmetProvider>`
- add `<Helmet>` SEO metadata to the Home, About, and Portfolio pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68506b9a18088323b10483acf2e2c958